### PR TITLE
Remove unnecessary stack manipulation

### DIFF
--- a/DevSound.asm
+++ b/DevSound.asm
@@ -202,20 +202,18 @@ DevSound_Play:
 	; Since this routine is called during an interrupt (which may
 	; happen in the middle of a routine), preserve all register
 	; values just to be safe.
+	; Other registers are saved at `.doUpdate`.
 	push	af
-	push	bc
-	push	de
-	push	hl
 	ld	a,[SoundEnabled]
 	and	a
 	jr	nz,.doUpdate	; if sound is enabled, jump ahead
-	pop	hl
-	pop	de
-	pop	bc
 	pop	af
 	ret
 	
 .doUpdate	
+	push	bc
+	push	de
+	push	hl
 	; get song timer
 	ld	a,[GlobalTimer]	; get global timer
 	and	a				; is GlobalTimer non-zero?


### PR DESCRIPTION
Only a and flags are affected by the `SoundEnabled` check.
Other registers need not be saved unless the jump occurs.
This saves some CPU time when sound is disabled, and some stack manipulation.
And 3 bytes.